### PR TITLE
Remove unnecessary steps from ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@
 1. Node.js
 2. Git
 
-### Install the following packages
-Run this commands from the command line
-> npm install -g gulp
-
 ## Run the project
 Run the following command from the command line in the project root folder
 > npm start


### PR DESCRIPTION
You do not need to install gulp globally when you are using npm scripts